### PR TITLE
BUGFIX: use Guzzle to download from GitHub

### DIFF
--- a/Classes/Composer/InstallerScripts.php
+++ b/Classes/Composer/InstallerScripts.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Flowpack\Prunner\Composer;
 
 use Composer\Script\Event;
+use GuzzleHttp\Client;
 use Neos\Utility\Files;
 use PharData;
 
@@ -71,8 +72,10 @@ EOD;
             echo '> Version:      ' . $version . $versionMessage . "\n";
             echo '> Platform:     ' . $platform . "\n";
             echo '> Architecture: ' . $architecture . "\n";
+
+            $httpClient = new Client();
             $downloadLink = sprintf('https://github.com/Flowpack/prunner/releases/download/v%s/prunner_%s_%s_%s.tar.gz', $version, $version, $platform, $architecture);
-            $downloadedFileContents = file_get_contents($downloadLink);
+            $downloadedFileContents = $httpClient->get($downloadLink)->getBody()->getContents();
             echo '> Download complete.' . "\n";
 
             file_put_contents('Data/Temporary/prunner.tar.gz', $downloadedFileContents);

--- a/Classes/Composer/InstallerScripts.php
+++ b/Classes/Composer/InstallerScripts.php
@@ -73,9 +73,9 @@ EOD;
             echo '> Platform:     ' . $platform . "\n";
             echo '> Architecture: ' . $architecture . "\n";
 
-            $httpClient = new Client();
             $downloadLink = sprintf('https://github.com/Flowpack/prunner/releases/download/v%s/prunner_%s_%s_%s.tar.gz', $version, $version, $platform, $architecture);
-            $downloadedFileContents = $httpClient->get($downloadLink)->getBody()->getContents();
+            $httpClient = new Client();
+            $httpClient->get($downloadLink, ['sink' => 'Data/Temporary/prunner.tar.gz']);
             echo '> Download complete.' . "\n";
 
             file_put_contents('Data/Temporary/prunner.tar.gz', $downloadedFileContents);


### PR DESCRIPTION
Previously used `file_get_contents ` does ignore all PHP proxy settings. The GuzzleHTTPClient resolves this problem