### PR TITLE
TASK: Update firebase/php-jwt due to CVE-2021-46743

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "neos/flow": "*",
         "neos/neos": "^7.0 || ^8.0",
         "guzzlehttp/guzzle": "^7.3",
-        "firebase/php-jwt": "^5.2"
+        "firebase/php-jwt": "^6.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This fixes the CVE issue mentioned in #7. As there are no changes required in the code of this package (only for `JWT::decode` or `JWT::parseKey` which is not used here), a simple update of the composer version will be enough.