### PR TITLE
FEATURE: connect to existing Prunner system service

### DIFF
--- a/Classes/Composer/InstallerScripts.php
+++ b/Classes/Composer/InstallerScripts.php
@@ -45,6 +45,14 @@ EOD;
 
     const DEFAULT_VERSION_TO_INSTALL = '1.0.1';
 
+    /**
+     * Downloads the prunner binaries from https://github.com/Flowpack/prunner to ./prunner.
+     *
+     * You can pin the prunner version in the composer.json#extra.prunner-version field.
+     * You can also set it to 'skip-download' to skip the download.
+     *
+     * @return void
+     */
     public static function postUpdateAndInstall()
     {
         $platform = php_uname('s'); // stuff like Darwin etc
@@ -57,6 +65,10 @@ EOD;
         if (isset($extra['prunner-version'])) {
             $version = $extra['prunner-version'];
             $versionMessage = ' (OVERRIDDEN in composer.json)';
+        }
+        if ($version === 'skip-download') {
+            echo '> Not downloading prunner (due to "skip-download" instruction in composer.json)';
+            return;
         }
 
         $baseDirectory = 'prunner';

--- a/Classes/Controller/ProxyController.php
+++ b/Classes/Controller/ProxyController.php
@@ -23,6 +23,12 @@ class ProxyController extends \Neos\Flow\Mvc\Controller\ActionController
     protected $directory;
 
     /**
+     * @Flow\InjectConfiguration(path="configFile")
+     * @var string
+     */
+    protected $configFile;
+
+    /**
      * @Flow\InjectConfiguration(path="jwtSecret")
      * @var string
      */
@@ -56,9 +62,8 @@ class ProxyController extends \Neos\Flow\Mvc\Controller\ActionController
         } else {
             try {
                 // Try to parse prunner config to get JWT secret
-                $config = Yaml::parseFile($this->directory . '/.prunner.yml');
-                $jwtSecret = $config['jwt_secret'];
-            } catch (ParseException $e) {
+                $jwtSecret = $this->loadJwtSecretFromConfigFile();
+            } catch (\RuntimeException $e) {
                 $this->response->setContentType('application/json');
                 $this->response->setStatusCode(500);
                 return json_encode(['error' => 'Invalid prunner configuration (could not read JWT secret)']);
@@ -86,5 +91,27 @@ class ProxyController extends \Neos\Flow\Mvc\Controller\ActionController
         $this->response->setStatusCode($response->getStatusCode());
 
         return $response->getBody();
+    }
+
+    /**
+     * @return string
+     */
+    private function loadJwtSecretFromConfigFile(): string
+    {
+        if ($this->configFile && file_exists($this->configFile)) {
+            $path = $this->configFile;
+        } elseif ($this->directory && file_exists($this->directory . '/.prunner.yml')) {
+            $path = $this->directory . '/.prunner.yml';
+        } else {
+            throw new \RuntimeException("Failed to locate prunner config file at " . $this->configFile . " or " . $this->directory . '/.prunner.yml');
+        }
+        try {
+            // Try to parse prunner config to get JWT secret
+            $config = Yaml::parseFile($path);
+            $jwtSecret = $config['jwt_secret'];
+        } catch (ParseException $e) {
+            throw new \RuntimeException('Invalid prunner configuration (could not read JWT secret)');
+        }
+        return $jwtSecret;
     }
 }

--- a/Classes/Dto/Job.php
+++ b/Classes/Dto/Job.php
@@ -63,7 +63,7 @@ class Job
     }
 
     /**
-     * @return string
+     * @return JobId
      */
     public function getId(): JobId
     {

--- a/Classes/Dto/Jobs.php
+++ b/Classes/Dto/Jobs.php
@@ -10,6 +10,7 @@ use Neos\Flow\Annotations as Flow;
  */
 class Jobs implements \IteratorAggregate
 {
+
     /**
      * @var Job[]
      */
@@ -19,7 +20,6 @@ class Jobs implements \IteratorAggregate
     {
         $this->jobs = $jobs;
     }
-
 
     public static function fromJsonArray(array $in): self
     {
@@ -43,21 +43,89 @@ class Jobs implements \IteratorAggregate
     }
 
     /**
+     * @return Jobs all scheduled jobs not yet started
+     */
+    public function waiting(): Jobs
+    {
+        return $this->filter(function (Job $job) {
+            return !$job->getStart();
+        });
+    }
+
+    /**
      * Filter running jobs
      *
      * @return Jobs
      */
     public function running(): Jobs
     {
-        $filteredJobs = [];
-        foreach ($this->jobs as $job) {
+        return $this->filter(function (Job $job) {
             // running = started jobs which have not finished.
-            if ($job->getStart() !== null && !$job->getEnd()) {
-                $filteredJobs[] = $job;
+            return $job->getStart() !== null && !$job->getEnd();
+        });
+    }
+
+    /**
+     * @return Jobs successful, canceled and failed jobs
+     */
+    public function completed(): Jobs
+    {
+        return $this->filter(function (Job $job) {
+            return $job->isCompleted();
+        });
+    }
+
+    /**
+     * @return Jobs successfully completed jobs
+     */
+    public function successful(): Jobs
+    {
+        return $this->filter(function (Job $job) {
+            return $job->isCompleted() && !$job->isErrored() && !$job->isCanceled();
+        });
+    }
+
+    /**
+     * @return Jobs canceled jobs
+     */
+    public function canceled(): Jobs
+    {
+        return $this->filter(function (Job $job) {
+            return $job->isCanceled();
+        });
+    }
+
+    /**
+     * @return Jobs failed jobs
+     */
+    public function errored(): Jobs
+    {
+        return $this->filter(function (Job $job) {
+            return $job->isErrored();
+        });
+    }
+
+    /**
+     * @param callable $predicate function(Job $job): bool
+     * @return Jobs all jobs where $predicate($job)
+     */
+    public function filter(callable $predicate): Jobs
+    {
+        $result = [];
+        foreach ($this->jobs as $job) {
+            if ($predicate($job)) {
+                $result[] = $job;
             }
         }
+        return new self($result);
+    }
 
-        return new self($filteredJobs);
+    /**
+     * @return Job[]
+     */
+    public function getArray(): array
+    {
+        return $this->jobs;
     }
 
     /**

--- a/Classes/Dto/Pipelines.php
+++ b/Classes/Dto/Pipelines.php
@@ -24,6 +24,13 @@ class Pipelines implements \IteratorAggregate
         return $pipelines;
     }
 
+    /**
+     * @return Pipeline[]
+     */
+    public function getArray(): array
+    {
+        return $this->pipelines;
+    }
 
     /**
      * @return \Iterator<Pipeline>

--- a/Classes/Dto/TaskResults.php
+++ b/Classes/Dto/TaskResults.php
@@ -139,6 +139,13 @@ final class TaskResults implements \IteratorAggregate, \Countable, ProtectedCont
     }
 
     /**
+     * @return TaskResult[]
+     */
+    public function getArray(): array  {
+        return $this->taskResults;
+    }
+
+    /**
      * @return \Iterator<TaskResult>
      */
     public function getIterator()

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -3,7 +3,10 @@ Flowpack:
     # Base URL to prunner API
     apiBaseUrl: 'http://localhost:9009/'
     # Working directory of prunner for loading config
+    # DEPRECATED: use configFile
     directory: '%FLOW_PATH_ROOT%'
+    # Path to the prunner config file to load the JWT secret for authentication
+    configFile: '%FLOW_PATH_ROOT%/.prunner.yml'
     # Explicitly set JWT secret if prunner config is not accessible
     jwtSecret: ~
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,20 @@ will be downloaded. However, it is possible to override this via `extra.prunner-
 }
 ```
 
+## Skip the Prunner binary download
+
+In case you want to install Prunner manually,
+you can skip the download of the Prunner entirely
+by setting `extra.prunner-version` in the root `composer.json` to `"skip-download"`.
+
+```json
+{
+  "extra": {
+    "prunner-version": "skip-download"
+  }
+}
+```
+
 ## Building the UI package
 
 In [prunner-ui](https://github.com/Flowpack/prunner-ui), run `yarn build`


### PR DESCRIPTION
## Features

The new features ease to use a shared Prunner for several Neos installations. This allows to configure the maximal number of concurrent pipelines for an entire server.

### Flowpack.Prunner.configFile to set path to _.prunner.yml_

The Prunner config file name containing the JWT secret not longer needs to be _.prunner.yml_. Now you can override the file name in the _Settings.yaml_

```yaml
Flowpack:
  Prunner:
    # Path to the prunner config file to load the JWT secret for authentication
    configFile: '%FLOW_PATH_ROOT%/.prunner.yml'
```

Existing configurations using _directory_ or _jwtSecret_ are still supported.

### Skip Prunner download

In the Composer post-install hook, the Prunner is installed. Now you can skip the download with the following config in the _composer.json_:

```json
"extra": {
    "prunner-version": "skip-download"
}
```

### Prunner Client has more Getters

For easier use I added getter functions, namely:

- `Jobs#waiting`
- `Jobs#completed`
- `Jobs#successful`
- `Jobs#canceled`
- `Jobs#errored`
- `Jobs#filter`
- `Jobs#getArray`
- `Pipelines#getArray`

## Bugfixes

The type annotation of `Job#getId` ist now correct.